### PR TITLE
fix: fix missing comma in range

### DIFF
--- a/lib/ranges.js
+++ b/lib/ranges.js
@@ -18,6 +18,7 @@ module.exports = {
 };
 
 function _createRequirement(range) {
+  range = range.replace(/(\d)(\s+\D)/, '$1,$2');
   return GemRequirement.$create(range.split(','));
 }
 

--- a/test/ranges/valid-range.test.js
+++ b/test/ranges/valid-range.test.js
@@ -11,6 +11,7 @@ test('validRange(range)', t => {
   t.is(validRange('~> 1.1.1.0'), '< 1.1.2, >= 1.1.1.0');
   t.is(validRange('~> 1.1.1.beta.1'), '< 1.2, >= 1.1.1.beta.1');
   t.is(validRange('> 2.1, < 2.4'), '< 2.4, > 2.1');
+  t.is(validRange('> 2.1 < 2.4'), '< 2.4, > 2.1');
 
   t.is(validRange(''), '>= 0');
   t.is(validRange(), null);


### PR DESCRIPTION
Fixes an issue for ranges that are unexpectedly formatted (a comma is missing), for example:

`>= 3.0.0 <= 3.0.3`