### PR TITLE
fix: ignore lodash vulnerability temporarily

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.5
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-LODASH-450202:
+    - lodash:
+        reason: None given
+        expires: '2019-08-01T21:28:30.406Z'
+patch: {}


### PR DESCRIPTION
it breaks a Registry test (temporarily disabled)