### PR TITLE
chore: codeowners -> boost

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/boost


### PR DESCRIPTION
Ecosystem versioning libraries are all owned by Boost.
