### PR TITLE
fix: roll back to min node 8 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Snyk/ruby-semver.git"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=8"
   },
   "dependencies": {
     "lodash": "^4.17.14"


### PR DESCRIPTION
This is a repo that is used in CLI so the min version must remain 8.

https://github.com/snyk/snyk/issues/1060