### PR TITLE
feat: switch to lodash 'dot' packages

### DIFF
--- a/lib/ruby/gem-requirement.js
+++ b/lib/ruby/gem-requirement.js
@@ -1,4 +1,6 @@
-const _ = require('@snyk/lodash');
+const _escapeRegExp = require('lodash.escaperegexp');
+const _flatten = require('lodash.flatten');
+const _uniq = require('lodash.uniq');
 const GemVersion = require('./gem-version');
 
 const OPS = {
@@ -11,7 +13,7 @@ const OPS = {
   '~>': (v, r) => v.compare(r) >= 0 && v.release().compare(r.bump()) < 0,
 };
 
-const quoted  = Object.keys(OPS).map(k => _.escapeRegExp(k)).join('|');
+const quoted  = Object.keys(OPS).map(k => _escapeRegExp(k)).join('|');
 const PATTERN_RAW = `\\s*(${quoted})?\\s*(${GemVersion.VERSION_PATTERN})\\s*`;
 // --
 // A regular expression that matches a requirement
@@ -78,9 +80,9 @@ module.exports = class GemRequirement {
   // same as <tt>">= 0"</tt>.
 
   constructor(...requirements) {
-    requirements = _(requirements).flatten().filter(Boolean).uniq().value();
+    requirements = _uniq(_flatten(requirements).filter(Boolean));
 
-    if (_.isEmpty(requirements)) {
+    if (0 === requirements.length) {
       this.requirements = [DefaultRequirement];
     } else {
       this.requirements = requirements.map(GemRequirement.parse);

--- a/lib/ruby/gem-version.js
+++ b/lib/ruby/gem-version.js
@@ -147,7 +147,6 @@
 //
 // For the last example, single-digit versions are automatically extended with
 // a zero to give a sensible result.
-const _ = require('@snyk/lodash');
 
 const VERSION_PATTERN = '[0-9]+(\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?';
 const ANCHORED_VERSION_PATTERN = new RegExp(`^\\s*(${VERSION_PATTERN})?\\s*$`);
@@ -379,8 +378,8 @@ class GemVersion {
         continue;
       }
 
-      if (_.isString(lhs) && _.isNumber(rhs)) { return -1; }
-      if (_.isNumber(lhs) && _.isString(rhs)) { return 1; }
+      if (isString(lhs) && isNumber(rhs)) { return -1; }
+      if (isNumber(lhs) && isString(rhs)) { return 1; }
 
       if (lhs < rhs) { return -1; }
       if (lhs > rhs) { return 1; }
@@ -394,6 +393,14 @@ class GemVersion {
   // def _version
   //   @version
   // end
+}
+
+function isString(val) {
+  return typeof val === 'string';
+}
+
+function isNumber(val) {
+  return typeof val === 'number';
 }
 
 GemVersion.VERSION_PATTERN = VERSION_PATTERN;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@snyk/lodash": "4.17.15-patch"
+    "lodash.escaperegexp": "^4.1.2",
+    "lodash.flatten": "^4.4.0",
+    "lodash.uniq": "^4.5.0"
   }
 }


### PR DESCRIPTION
This reduces our overall dependence on lodash as a whole.

Each of these functions only has one use, and two of the three
are all on one line. Maybe we could rewrite that.