### PR TITLE
fix: Fix version validation

### DIFF
--- a/lib/ruby/gem-version.ts
+++ b/lib/ruby/gem-version.ts
@@ -149,7 +149,7 @@
 // a zero to give a sensible result.
 
 const VERSION_PATTERN =
-  '[0-9]+(.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(.[0-9A-Za-z-]+)*)?';
+  '[0-9]+(\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?';
 const ANCHORED_VERSION_PATTERN = new RegExp(`^\\s*(${VERSION_PATTERN})?\\s*$`);
 
 export type MaybeGemVersion = GemVersion | string;

--- a/test/functions/valid.test.ts
+++ b/test/functions/valid.test.ts
@@ -5,6 +5,8 @@ import { valid } from '../../';
 describe('test valid', () => {
   it('valid(v)', () => {
     expect(valid('1')).toBe('1');
+    expect(valid('1 ')).toBe('1');
+    expect(valid(' 1')).toBe('1');
     expect(valid('1.1')).toBe('1.1');
     expect(valid('1.1.2')).toBe('1.1.2');
     expect(valid('1.1.2.3')).toBe('1.1.2.3');
@@ -12,6 +14,8 @@ describe('test valid', () => {
     expect(valid('1.1.2.pre.4')).toBe('1.1.2.pre.4');
 
     expect(valid('nonsense')).toBe(null);
+    expect(valid('1.2<3')).toBe(null);
+    expect(valid('1.2 3')).toBe(null);
     expect(valid('')).toBe(null);
     expect(valid(null)).toBe(null);
     // expect(valid()).toBe(null); not valid with typescript


### PR DESCRIPTION
- Ported Regex was missing some escape chars resulting in very permissive version validation